### PR TITLE
feat: User 보안 제외 회원가입 정보수정 정보조회 구현 (#25)

### DIFF
--- a/server/src/main/java/seb/project/Codetech/global/exception/BusinessLogicException.java
+++ b/server/src/main/java/seb/project/Codetech/global/exception/BusinessLogicException.java
@@ -1,0 +1,14 @@
+package seb.project.Codetech.global.exception;
+
+import lombok.Getter;
+
+public class BusinessLogicException extends RuntimeException{
+
+    @Getter
+    private final ExceptionCode exceptionCode;
+
+    public BusinessLogicException(ExceptionCode exceptionCode){
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+}

--- a/server/src/main/java/seb/project/Codetech/global/exception/ExceptionCode.java
+++ b/server/src/main/java/seb/project/Codetech/global/exception/ExceptionCode.java
@@ -1,0 +1,19 @@
+package seb.project.Codetech.global.exception;
+
+import lombok.Getter;
+
+public enum ExceptionCode {
+    USER_NOT_FOUND(404,"회원을 찾을 수 없습니다."),
+    USER_EXISTS(409,"회원이 이미 존재합니다.");
+
+    @Getter
+    private int code;
+
+    @Getter
+    private String message;
+
+    ExceptionCode(int code, String message){
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/server/src/main/java/seb/project/Codetech/global/exception/GlobalExceptionAdvice.java
+++ b/server/src/main/java/seb/project/Codetech/global/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,37 @@
+package seb.project.Codetech.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import seb.project.Codetech.global.response.ErrorResponse;
+
+import javax.validation.ConstraintViolationException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        final ErrorResponse response = ErrorResponse.of(e.getBindingResult());
+        return response;
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleConstraintViolationException(ConstraintViolationException e){
+        final ErrorResponse response = ErrorResponse.of(e.getConstraintViolations());
+        return response;
+    }
+
+    @ExceptionHandler
+    public ResponseEntity handleBusinessLogicException(BusinessLogicException e){
+        final ErrorResponse response = ErrorResponse.of(e.getExceptionCode());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(e.getExceptionCode().getCode()));
+    }
+}

--- a/server/src/main/java/seb/project/Codetech/global/response/ErrorResponse.java
+++ b/server/src/main/java/seb/project/Codetech/global/response/ErrorResponse.java
@@ -1,0 +1,95 @@
+package seb.project.Codetech.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import seb.project.Codetech.global.exception.ExceptionCode;
+
+import javax.validation.ConstraintViolation;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class ErrorResponse {
+    private int code;
+    private String message;
+    private List<FieldError> fieldErrors;
+    private List<ConstraintViolationError> violationErrors;
+
+    private ErrorResponse(int code, String message){
+        this.code = code;
+        this.message = message;
+    }
+
+    private ErrorResponse(final List<FieldError> fieldErrors,
+                          final List<ConstraintViolationError> violationErrors){
+        this.fieldErrors = fieldErrors;
+        this.violationErrors = violationErrors;
+    }
+
+    @Getter
+    public static class FieldError{
+        private String field;
+        private Object rejectedValue;
+        private String reason;
+
+        private FieldError(String field, Object rejectedValue, String reason){
+            this.field = field;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(BindingResult bindingResult){
+            final List<org.springframework.validation.FieldError> fieldErrors =bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(error.getField(),
+                            error.getRejectedValue() == null ?
+                            "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    public static class ConstraintViolationError{
+        private String propertyPath;
+        private Object rejectedValue;
+        private String reason;
+
+        private ConstraintViolationError(String propertyPath, Object rejectedValue, String reason){
+            this.propertyPath = propertyPath;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<ConstraintViolationError> of(Set<ConstraintViolation<?>> constraintViolations){
+            return constraintViolations.stream()
+                    .map(constraintViolation -> new ConstraintViolationError(
+                            constraintViolation.getPropertyPath().toString(),
+                            constraintViolation.getInvalidValue().toString(),
+                            constraintViolation.getMessage()
+                    )).collect(Collectors.toList());
+        }
+    }
+
+    public static ErrorResponse of(BindingResult bindingResult){
+        return new ErrorResponse(FieldError.of(bindingResult), null);
+    }
+
+    public static ErrorResponse of(Set<ConstraintViolation<?>> violations){
+        return new ErrorResponse(null,ConstraintViolationError.of(violations));
+    }
+
+    public static ErrorResponse of(ExceptionCode exceptionCode){
+        return new ErrorResponse(exceptionCode.getCode(), exceptionCode.getMessage());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus){
+        return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message){
+        return new ErrorResponse(httpStatus.value(), message);
+    }
+}

--- a/server/src/main/java/seb/project/Codetech/global/response/PageInfo.java
+++ b/server/src/main/java/seb/project/Codetech/global/response/PageInfo.java
@@ -1,0 +1,13 @@
+package seb.project.Codetech.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PageInfo {
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/server/src/main/java/seb/project/Codetech/user/controller/UserController.java
+++ b/server/src/main/java/seb/project/Codetech/user/controller/UserController.java
@@ -38,4 +38,10 @@ public class UserController {
         User user = userService.updateUser(mapper.userPatchDtoToUser(patch),id);
         return ResponseEntity.ok(mapper.userToUserResponseDto(user));
     }
+
+    @GetMapping("/user/{id}")
+    public ResponseEntity getUser(@PathVariable("id") Long id){
+        User user = userService.findVerifiedUser(id);
+        return ResponseEntity.ok(mapper.userToUserResponseDto(user));
+    }
 }

--- a/server/src/main/java/seb/project/Codetech/user/controller/UserController.java
+++ b/server/src/main/java/seb/project/Codetech/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package seb.project.Codetech.user.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import seb.project.Codetech.user.dto.UserPostDto;
+import seb.project.Codetech.user.entity.User;
+import seb.project.Codetech.user.mapper.UserMapper;
+import seb.project.Codetech.user.service.UserService;
+
+import javax.validation.Valid;
+
+@RestController
+@Validated
+@RequestMapping("/api")
+@Slf4j
+public class UserController {
+    private final UserService userService;
+    private final UserMapper mapper;
+
+    public UserController(UserService userService, UserMapper mapper){
+        this.userService = userService;
+        this.mapper = mapper;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity registerUser(@Valid @RequestBody UserPostDto register){
+        User user = mapper.userRegisterToUser(register);
+        User registerUser = userService.registerUser(user);
+        return ResponseEntity.ok(registerUser);
+    }
+}

--- a/server/src/main/java/seb/project/Codetech/user/controller/UserController.java
+++ b/server/src/main/java/seb/project/Codetech/user/controller/UserController.java
@@ -3,10 +3,8 @@ package seb.project.Codetech.user.controller;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import seb.project.Codetech.user.dto.UserPatchDto;
 import seb.project.Codetech.user.dto.UserPostDto;
 import seb.project.Codetech.user.entity.User;
 import seb.project.Codetech.user.mapper.UserMapper;
@@ -32,5 +30,12 @@ public class UserController {
         User user = mapper.userRegisterToUser(register);
         User registerUser = userService.registerUser(user);
         return ResponseEntity.ok(registerUser);
+    }
+
+    @PatchMapping("/user")
+    public ResponseEntity patchUser(@Valid @RequestBody UserPatchDto patch,
+                                    Long id){
+        User user = userService.updateUser(mapper.userPatchDtoToUser(patch),id);
+        return ResponseEntity.ok(mapper.userToUserResponseDto(user));
     }
 }

--- a/server/src/main/java/seb/project/Codetech/user/dto/UserDto.java
+++ b/server/src/main/java/seb/project/Codetech/user/dto/UserDto.java
@@ -1,0 +1,4 @@
+package seb.project.Codetech.user.dto;
+
+public class UserDto {
+}

--- a/server/src/main/java/seb/project/Codetech/user/dto/UserPatchDto.java
+++ b/server/src/main/java/seb/project/Codetech/user/dto/UserPatchDto.java
@@ -1,0 +1,16 @@
+package seb.project.Codetech.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserPatchDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String password;
+    private String image;
+}

--- a/server/src/main/java/seb/project/Codetech/user/dto/UserPostDto.java
+++ b/server/src/main/java/seb/project/Codetech/user/dto/UserPostDto.java
@@ -1,0 +1,20 @@
+package seb.project.Codetech.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class UserPostDto {
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    private String password;
+}

--- a/server/src/main/java/seb/project/Codetech/user/dto/UserResponseDto.java
+++ b/server/src/main/java/seb/project/Codetech/user/dto/UserResponseDto.java
@@ -1,0 +1,15 @@
+package seb.project.Codetech.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserResponseDto {
+    private String email;
+    private String nickname;
+    private String image;
+    private Long point;
+}

--- a/server/src/main/java/seb/project/Codetech/user/entity/User.java
+++ b/server/src/main/java/seb/project/Codetech/user/entity/User.java
@@ -44,10 +44,10 @@ public class User extends BaseTime {
     private String image;
 
     @Column(nullable = false)
-    private Long point;
+    private Long point = 0L;
 
     @Column(nullable = false)
-    private Boolean status;
+    private Boolean status = false;
 
     @OneToMany(mappedBy = "user")
     private List<Review> reviews = new ArrayList<>();

--- a/server/src/main/java/seb/project/Codetech/user/entity/User.java
+++ b/server/src/main/java/seb/project/Codetech/user/entity/User.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import seb.project.Codetech.discount.entity.Discount;
 import seb.project.Codetech.discount.entity.DiscountComment;
@@ -25,6 +26,7 @@ import seb.project.Codetech.snackreview.entity.SnackReview;
 @Getter
 @Setter
 @Entity
+@NoArgsConstructor
 public class User extends BaseTime {
 
     @Id

--- a/server/src/main/java/seb/project/Codetech/user/mapper/UserMapper.java
+++ b/server/src/main/java/seb/project/Codetech/user/mapper/UserMapper.java
@@ -1,10 +1,16 @@
 package seb.project.Codetech.user.mapper;
 
 import org.mapstruct.Mapper;
+import seb.project.Codetech.user.dto.UserPatchDto;
 import seb.project.Codetech.user.dto.UserPostDto;
+import seb.project.Codetech.user.dto.UserResponseDto;
 import seb.project.Codetech.user.entity.User;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
     User userRegisterToUser(UserPostDto register);
+
+    User userPatchDtoToUser(UserPatchDto userPatchDto);
+
+    UserResponseDto userToUserResponseDto(User user);
 }

--- a/server/src/main/java/seb/project/Codetech/user/mapper/UserMapper.java
+++ b/server/src/main/java/seb/project/Codetech/user/mapper/UserMapper.java
@@ -1,0 +1,10 @@
+package seb.project.Codetech.user.mapper;
+
+import org.mapstruct.Mapper;
+import seb.project.Codetech.user.dto.UserPostDto;
+import seb.project.Codetech.user.entity.User;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    User userRegisterToUser(UserPostDto register);
+}

--- a/server/src/main/java/seb/project/Codetech/user/repository/UserRepository.java
+++ b/server/src/main/java/seb/project/Codetech/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package seb.project.Codetech.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import seb.project.Codetech.user.entity.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/server/src/main/java/seb/project/Codetech/user/service/UserService.java
+++ b/server/src/main/java/seb/project/Codetech/user/service/UserService.java
@@ -31,4 +31,26 @@ public class UserService {
         Optional<User> user = userRepository.findByEmail(email);
         if(user.isPresent()) throw new BusinessLogicException(ExceptionCode.USER_EXISTS);
     }
+
+    public User updateUser(User user, Long id){
+        User findUser = findVerifiedUser(user.getId());
+
+        Optional.ofNullable(user.getEmail()).ifPresent(findUser::setEmail);
+        Optional.ofNullable(user.getNickname()).ifPresent(findUser::setNickname);
+        Optional.ofNullable(user.getPassword()).ifPresent(findUser::setPassword);
+        Optional.ofNullable(user.getImage()).ifPresent(findUser::setImage);
+
+        return userRepository.save(findUser);
+    }
+
+    public Long findUserId(String email) {
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        User findUser = optionalUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+        return findUser.getId();
+    }
+
+    public User findVerifiedUser(long id){
+        Optional<User> optionalUser = userRepository.findById(id);
+        return optionalUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+    }
 }

--- a/server/src/main/java/seb/project/Codetech/user/service/UserService.java
+++ b/server/src/main/java/seb/project/Codetech/user/service/UserService.java
@@ -3,6 +3,8 @@ package seb.project.Codetech.user.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import seb.project.Codetech.global.exception.BusinessLogicException;
+import seb.project.Codetech.global.exception.ExceptionCode;
 import seb.project.Codetech.user.entity.User;
 import seb.project.Codetech.user.repository.UserRepository;
 
@@ -27,6 +29,6 @@ public class UserService {
 
     private void verifyExistsEmail(String email) {
         Optional<User> user = userRepository.findByEmail(email);
-        if(user.isPresent()) throw new IllegalArgumentException("이미 사용중인 이메일 입니다.");
+        if(user.isPresent()) throw new BusinessLogicException(ExceptionCode.USER_EXISTS);
     }
 }

--- a/server/src/main/java/seb/project/Codetech/user/service/UserService.java
+++ b/server/src/main/java/seb/project/Codetech/user/service/UserService.java
@@ -1,0 +1,32 @@
+package seb.project.Codetech.user.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import seb.project.Codetech.user.entity.User;
+import seb.project.Codetech.user.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@Slf4j
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository){
+        this.userRepository = userRepository;
+    }
+    public User registerUser(User user) {
+        verifyExistsEmail(user.getEmail());
+
+        User savedUser = userRepository.save(user);
+
+        return savedUser;
+    }
+
+    private void verifyExistsEmail(String email) {
+        Optional<User> user = userRepository.findByEmail(email);
+        if(user.isPresent()) throw new IllegalArgumentException("이미 사용중인 이메일 입니다.");
+    }
+}


### PR DESCRIPTION
## Description
user의 보안을 제외한 회원가입, 내정보 수정, 내정보 조회를 간단하게 구현했습니다. ( #25)
BusinessLogicException을 추가했으니 필요하신분은 원하는 에러문구를 추가하시면 될것 같습니다.
pageinfo는 창일님이 이미 추가했으므로 다음 이슈때 삭제하겠습니다.

## To Reviewers
누락된 부분이나 변수명 확인 부탁드립니다!